### PR TITLE
Fix some bugs, add a top-sticky roundend message

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -194,6 +194,7 @@ p {
 	padding: .25em .5em;
 	background: white;
 	max-width: 300px;
+	z-index: 1;
 }
 
 #filters {
@@ -217,6 +218,21 @@ button, input[type=submit] { display: block; width: 100%; }
 	overflow: auto;
 	white-space: pre;
 	margin-left: 11em;
+}
+
+.stickytop {
+	position: sticky;
+	top: -1px;
+	display: inline-block;
+	width: 100%;
+	text-align: center;
+	padding: 3px;
+}
+
+.hogwild {
+	font-weight: bold;
+	background-color: #800;
+	color: white;
 }
 
 

--- a/functions-logs.php
+++ b/functions-logs.php
@@ -7,6 +7,7 @@
 
 
 	function pretty_log($line, $time, $type, $msg) {
+
 		static $firstTimestamp	= null;
 
 		$typeL	= strtolower($type);
@@ -50,6 +51,10 @@
 			$msg = $msgdom->saveHTML();
 		} else {
 			$msg	= '<span class="message">'. $msg .'</span>';
+		}
+
+		if (stripos($msg, "the emergency shuttle has arrived at centcom") !== false) {
+			$msg .= "<div class='stickytop hogwild'>Round ended!</div>";
 		}
 
 		$timeReal	= $time;

--- a/functions-logs.php
+++ b/functions-logs.php
@@ -212,7 +212,7 @@ E;
 
 
 		$a = [];
-		$m = preg_match('#((?:[0-9.]+)?), ([0-9.]+), ([0-9.]+), ([0-9.]+), ([0-9.]+)#', $matches[1], $a);
+		$m = preg_match('#((?:[0-9.]+)?), ([0-9.]+)(?:, ([0-9.]+), ([0-9.]+), ([0-9.]+))?#', $matches[1], $a);
 
 		/*
 		print "<pre>";
@@ -224,6 +224,9 @@ E;
 		$dam	= ['brain', 'oxy', 'tox', 'burn', 'brute'];
 		$m		= 0;
 		array_shift($a);
+		if (count($a) == 2) { // silicon
+		  $dam = ['burn', 'brute'];
+		}
 		foreach ($dam as $n => $poo) {
 
 			$temp	= $a[$n];

--- a/functions-logs.php
+++ b/functions-logs.php
@@ -214,11 +214,11 @@ E;
 		$a = [];
 		$m = preg_match('#((?:[0-9.]+)?), ([0-9.]+), ([0-9.]+), ([0-9.]+), ([0-9.]+)#', $matches[1], $a);
 
-		if(count($a) <= 1) {
-			print "<pre>";
-			var_dump($matches, $m, $a);
-			die();
-		}
+		/*
+		print "<pre>";
+		var_dump($matches, $m, $a);
+		die();
+		*/
 
 		$out	= "<span class='damage'>";
 		$dam	= ['brain', 'oxy', 'tox', 'burn', 'brute'];

--- a/functions-logs.php
+++ b/functions-logs.php
@@ -212,13 +212,13 @@ E;
 
 
 		$a = [];
-		$m = preg_match('#([0-9.]+), ([0-9.]+), ([0-9.]+), ([0-9.]+), ([0-9.]+)#', $matches[1], $a);
+		$m = preg_match('#((?:[0-9.]+)?), ([0-9.]+), ([0-9.]+), ([0-9.]+), ([0-9.]+)#', $matches[1], $a);
 
-		/*
-		print "<pre>";
-		var_dump($matches, $m, $a);
-		die();
-		*/
+		if(count($a) <= 1) {
+			print "<pre>";
+			var_dump($matches, $m, $a);
+			die();
+		}
 
 		$out	= "<span class='damage'>";
 		$dam	= ['brain', 'oxy', 'tox', 'burn', 'brute'];
@@ -227,9 +227,10 @@ E;
 		foreach ($dam as $n => $poo) {
 
 			$temp	= $a[$n];
-			$temp2	= ceil($temp);
+			$temp2	= $temp == "" ? "null" : ceil($temp);
 			$out	.= " <span class='damage-$poo' title='$poo: $temp'>$temp2</span> ";
-			$m += $temp2 + 1;
+			if (is_numeric($temp2))
+				$m += $temp2 + 1;
 
 		}
 		$out	.= "</span> ";

--- a/log-viewer.php
+++ b/log-viewer.php
@@ -40,7 +40,7 @@
 		die("Error opening log. Sorry. It broke. Oh well.");
 	}
 
-
+	$title = $server . " - " . $log;
 	require("html/log_header.php");
 
 	// This is arbitrarily chosen as a "round ended" semaphore, but in theory it could be anything.

--- a/log-viewer.php
+++ b/log-viewer.php
@@ -137,7 +137,7 @@ ckey2
 			$matched_any	= 0;
 			$print = false;
 			foreach ($search as $term) {
-				if ($term{0} === "+") {
+				if ($term[0] === "+") {
 					$has_required = 1;
 					if (stripos($line, substr($term, 1)) === false) {
 						$print	= false;
@@ -147,13 +147,13 @@ ckey2
 					// Continue to see if another term matches somewhere
 					continue;
 
-				} elseif ($term{0} === "-" && stripos($line, substr($term, 1)) !== false) {
+				} elseif ($term[0] === "-" && stripos($line, substr($term, 1)) !== false) {
 					// Has ignored term; ignore line
 					$print = false;
 					break;
 				}
 
-				if ($term{0} === "+" || $term{0} === "-") {
+				if ($term[0] === "+" || $term[0] === "-") {
 					$term	= substr($term, 1);
 					$print	= ($print === null ? true : false);
 				}


### PR DESCRIPTION

- Replaces indexing using `{ }` by indexing using `[ ]` because PHP 8 refuses to even run the scripts with the first one.
- Brain damage can apparently sometimes be logged as empty string when it's null. This PR makes that render properly-ish.
- The header file uses a nonexistent `$title` variable. This PR adds such variable and makes it be `$server - $log`.
- Borg damage reporting contains only two numbers - burn and brute. This PR makes this render properly.
- When you scroll past the shuttle-docking-at-centcom message there will now be a sticky thing on top of your screen so you
 don't mistake these logs for actual in-game logs.

https://user-images.githubusercontent.com/358431/154823507-604db301-09de-47c2-8503-33fa2907acfc.mp4
