### PR TITLE
filter out topic log by default

### DIFF
--- a/log-viewer.php
+++ b/log-viewer.php
@@ -80,9 +80,13 @@
 		'tgui',
 		'topic',
 	];
+	$unchecked_types = [
+		'tgui',
+		'topic',
+	];
 
 	foreach ($types as $type) {
-		print "<label class='opt opt-$type'><input type='checkbox' name='$type' ". ($type !== "tgui" ? "checked" : "") ." disabled> $type</label>\n";
+		print "<label class='opt opt-$type'><input type='checkbox' name='$type' ". (in_array($type, $unchecked_types) ? "" : "checked") ." disabled> $type</label>\n";
 	}
 
 


### PR DESCRIPTION
Filters the topic log out by default.

Topic log grows quite large and isn't desired by default in most instances, resulting in a cluttered log viewing experience